### PR TITLE
Are.na feed should be an actual list

### DIFF
--- a/_includes/arena_feed.html
+++ b/_includes/arena_feed.html
@@ -1,4 +1,4 @@
-<div class="arena-content-feed">
+<ul class="arena-content-feed">
   {% for block in site.data[page.channel].contents %}
     <li style="padding-bottom: 15px; margin-top: 0px; list-style:none;">
       <a target="_blank" href="https://www.are.na/{{block.user.slug}}/{{block.slug}}">
@@ -36,4 +36,4 @@
       </a>
     </li>
   {% endfor %}
-</div>
+</ul>

--- a/_site/ideas.html
+++ b/_site/ideas.html
@@ -141,7 +141,7 @@ ______________________________________________________________________\///______
     </div>
     <div class="col-sm-3" style="padding-right: 15px; padding-left: 30px;">
       <div class="page-content">
-        <div class="arena-content-feed">
+        <ul class="arena-content-feed">
   
     <li style="padding-bottom: 15px; margin-top: 0px; list-style:none;">
       <a target="_blank" href="https://www.are.na/consortia-systems/permaflux">
@@ -238,7 +238,7 @@ ______________________________________________________________________\///______
       </a>
     </li>
   
-</div>
+</ul>
 
       </div>
     </div>


### PR DESCRIPTION
So I'm not totally sure if this will work but I'm guessing that github pages will filter out invalid HTML. `li` elements should only exist nested in a list element, otherwise the HTML will be invalid. 

Also guessing this because if you look at `ideas.html` you can see the Are.na feed, it's just not showing up on the published version.